### PR TITLE
[fix] Remove is_open() guard from adapter command handler

### DIFF
--- a/src/franka_bringup/scripts/crisp_py_gripper_adapter.py
+++ b/src/franka_bringup/scripts/crisp_py_gripper_adapter.py
@@ -212,18 +212,10 @@ class CrispPyGripperAdapater(Node):
         gripper_command = msg.data[0]
         self.get_logger().debug(f"Received a command to move the gripper: {msg}")
 
-        if (
-            gripper_command <= 0.9
-            and self.gripper_client.is_open()
-            and not self.is_closing
-        ):
+        if gripper_command <= 0.9 and not self.is_closing:
             self.gripper_client.close()
             self.is_closing = True
-        elif (
-            gripper_command > 0.9
-            and not self.gripper_client.is_open()
-            and self.is_closing
-        ):
+        elif gripper_command > 0.9 and self.is_closing:
             self.gripper_client.open()
             self.is_closing = False
 


### PR DESCRIPTION
The width-based is_open() check prevented grasping wide objects — when the gripper closed on a large object, the width remained above the threshold, so the adapter thought the gripper was still open and blocked state transitions. Use the is_closing flag alone to track the commanded state.